### PR TITLE
add upstream fix

### DIFF
--- a/libcinnamon-desktop/gnome-rr.c
+++ b/libcinnamon-desktop/gnome-rr.c
@@ -2184,7 +2184,8 @@ gnome_rr_crtc_set_config_with_time (GnomeRRCrtc      *crtc,
 	for (i = 0; i < n_outputs; ++i)
 	    g_array_append_val (output_ids, outputs[i]->id);
     }
-    
+
+    gdk_error_trap_push ();   
     status = XRRSetCrtcConfig (DISPLAY (crtc), info->resources, crtc->id,
 			       timestamp, 
 			       x, y,
@@ -2195,16 +2196,16 @@ gnome_rr_crtc_set_config_with_time (GnomeRRCrtc      *crtc,
     
     g_array_free (output_ids, TRUE);
 
-    if (status == RRSetConfigSuccess)
-	result = TRUE;
-    else {
-	result = FALSE;
+    if (gdk_error_trap_pop () || status != RRSetConfigSuccess) {
 	/* Translators: CRTC is a CRT Controller (this is X terminology).
 	 * It is *very* unlikely that you'll ever get this error, so it is
 	 * only listed for completeness. */
 	g_set_error (error, GNOME_RR_ERROR, GNOME_RR_ERROR_RANDR_ERROR,
 		     _("could not set the configuration for CRTC %d"),
 		     (int) crtc->id);
+        return FALSE;
+    } else {
+        result = TRUE;
     }
     
     return result;


### PR DESCRIPTION
gnome-rr: Fix crash when XRRSetCrtcConfig() fails
It's possible for XRRSetCrtcConfig() to fail so we should wrap it in gkd_error_traps. https://bugzilla.gnome.org/show_bug.cgi?id=703034 
