### PR TITLE
Fix wallpaper thread lockups and whitespace

### DIFF
--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -1728,7 +1728,7 @@ gnome_bg_create_and_set_surface_as_root_thread (void *args)
         pthread_mutex_lock(&bgmutex);
         copied = 1;
         pthread_mutex_unlock(&bgmutex);
-        pthread_cond_signal(&bgcv);
+        pthread_cond_broadcast(&bgcv);
 
         int width, height;
         cairo_surface_t *surface;


### PR DESCRIPTION
My previous fix used some unnecessarily complicated code, and caused occasional lockups due to timing. That won't happen anymore. I also fixed the whitespace in my code (spaces, not tabs).
