### PR TITLE
Stop build spam

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 AC_INIT(cinnamon-desktop, 2.4.0)
 AC_CONFIG_SRCDIR(libcinnamon-desktop)
 
-AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz tar-ustar])
+AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz tar-ustar subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
```
libcinnamon-desktop/libgsystem/Makefile-libgsystem.am:20: warning: source file '$(libgsystem_srcpath)/gsystem-local-alloc.c' is in a subdirectory,
libcinnamon-desktop/libgsystem/Makefile-libgsystem.am:20: but option 'subdir-objects' is disabled
libcinnamon-desktop/Makefile.am:22:   'libcinnamon-desktop/libgsystem/Makefile-libgsystem.am' included from here
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
libcinnamon-desktop/libgsystem/Makefile-libgsystem.am:20: warning: source file '$(libgsystem_srcpath)/gsystem-file-utils.c' is in a subdirectory,
libcinnamon-desktop/libgsystem/Makefile-libgsystem.am:20: but option 'subdir-objects' is disabled
libcinnamon-desktop/Makefile.am:22:   'libcinnamon-desktop/libgsystem/Makefile-libgsystem.am' included from here
```