### PR TITLE
correct errors detected by scan-build

### DIFF
--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -2218,7 +2218,7 @@ create_img_thumbnail (GnomeBG                      *bg,
 			SlideShow *show = get_as_slideshow (bg, bg->filename);
 
 			if (show) {
-				double alpha;
+				double alpha=255;
 				Slide *slide;
 
 				if (frame_num == -1)
@@ -2322,8 +2322,17 @@ find_best_size (GSList *sizes, gint width, gint height)
 				best = size;
 			} 
 			else if (d == distance) {
-				if (abs (size->width - width) < abs (best->width - width)) {
-					best = size;
+				if (best == NULL)
+				{
+					if (abs (size->width - width) < abs (width)) {
+						best = size;
+					}
+				}
+				else
+				{
+					if (abs (size->width - width) < abs (best->width - width)) {
+						best = size;
+					}
 				}
 			}
 		}

--- a/libcinnamon-desktop/gnome-thumbnail-pixbuf-utils.c
+++ b/libcinnamon-desktop/gnome-thumbnail-pixbuf-utils.c
@@ -144,22 +144,25 @@ gnome_desktop_thumbnail_scale_down_pixbuf (GdkPixbuf *pixbuf,
 				src += source_rowstride;
 			}
 			
-			if (has_alpha) {
-				if (a != 0) {
-					*dest++ = r / a;
-					*dest++ = g / a;
-					*dest++ = b / a;
-					*dest++ = a / n_pixels;
+			if (n_pixels != 0)  /* avoid any possible divide by zero */
+			{			
+				if (has_alpha) {
+					if (a != 0) {
+						*dest++ = r / a;
+						*dest++ = g / a;
+						*dest++ = b / a;
+						*dest++ = a / n_pixels;
+					} else {
+						*dest++ = 0;
+						*dest++ = 0;
+						*dest++ = 0;
+						*dest++ = 0;
+					}
 				} else {
-					*dest++ = 0;
-					*dest++ = 0;
-					*dest++ = 0;
-					*dest++ = 0;
+					*dest++ = r / n_pixels;
+					*dest++ = g / n_pixels;
+					*dest++ = b / n_pixels;
 				}
-			} else {
-				*dest++ = r / n_pixels;
-				*dest++ = g / n_pixels;
-				*dest++ = b / n_pixels;
 			}
 			
 			s_x1 = s_x2;


### PR DESCRIPTION
Avoid one potential divide by zero, and one case where a pointer could be used before it was set.