### PR TITLE
Support keybindings to toggle horizontal/vertical maximized state

### DIFF
--- a/schemas/org.cinnamon.desktop.keybindings.wm.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.keybindings.wm.gschema.xml.in.in
@@ -159,6 +159,14 @@
       <default><![CDATA[['<Alt>F10']]]></default>
       <summary>Toggle maximization state</summary>
     </key>
+    <key type="as" name="toggle-maximized-vertically">
+      <default>[]</default>
+      <summary>Toggle vertical maximization state</summary>
+    </key>
+    <key type="as" name="toggle-maximized-horizontally">
+      <default>[]</default>
+      <summary>Toggle horizontal maximization state</summary>
+    </key>
     <key type="as" name="toggle-above">
       <default>[]</default>
       <summary>Toggle window always appearing on top</summary>


### PR DESCRIPTION
Some graphical applications are ment to be controlled mainly though the
keyboard, think terminal windows.  For these it's extremely handy to have
keybindings to toggle horizontal or vertical maximized state, so one
doesn't have to reach out to the mouse.

Add corresponding keys 'toggle-maximized-horizontally' and
'toggle-maximized-vertically'.

See my related pull requests in the [muffin](https://github.com/linuxmint/muffin/pull/192) and [Cinnamon](https://github.com/linuxmint/Cinnamon/pull/4199) repositories.