### PR TITLE
fix xml bg warning

### DIFF
--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -2836,14 +2836,13 @@ handle_text (GMarkupParseContext *context,
 	     GError             **err)
 {
 	SlideShow *parser = user_data;
+	FileSize *fs;
+	gint i;
 
 	g_return_if_fail (parser != NULL);
 	g_return_if_fail (parser->slides != NULL);
-	g_return_if_fail (parser->slides->tail != NULL);
 
-	Slide *slide = parser->slides->tail->data;
-	FileSize *fs;
-	gint i;
+	Slide *slide = parser->slides->tail ? parser->slides->tail->data : NULL;
 
 	if (stack_is (parser, "year", "starttime", "background", NULL)) {
 		parser->start_tm.tm_year = parse_int (text) - 1900;
@@ -2865,11 +2864,15 @@ handle_text (GMarkupParseContext *context,
 	}
 	else if (stack_is (parser, "duration", "static", "background", NULL) ||
 		 stack_is (parser, "duration", "transition", "background", NULL)) {
+		g_return_if_fail (slide != NULL);
+
 		slide->duration = g_strtod (text, NULL);
 		parser->total_duration += slide->duration;
 	}
 	else if (stack_is (parser, "file", "static", "background", NULL) ||
 		 stack_is (parser, "from", "transition", "background", NULL)) {
+		g_return_if_fail (slide != NULL);
+
 		for (i = 0; text[i]; i++) {
 			if (!g_ascii_isspace (text[i]))
 				break;
@@ -2886,12 +2889,16 @@ handle_text (GMarkupParseContext *context,
 	}
 	else if (stack_is (parser, "size", "file", "static", "background", NULL) ||
 		 stack_is (parser, "size", "from", "transition", "background", NULL)) {
+		g_return_if_fail (slide != NULL);
+
 		fs = slide->file1->data;
 		fs->file = g_strdup (text);
 		if (slide->file1->next != NULL)
 			parser->has_multiple_sizes = TRUE; 
 	}
 	else if (stack_is (parser, "to", "transition", "background", NULL)) {
+		g_return_if_fail (slide != NULL);
+
 		for (i = 0; text[i]; i++) {
 			if (!g_ascii_isspace (text[i]))
 				break;
@@ -2907,6 +2914,8 @@ handle_text (GMarkupParseContext *context,
 			parser->has_multiple_sizes = TRUE;                       
 	}
 	else if (stack_is (parser, "size", "to", "transition", "background", NULL)) {
+		g_return_if_fail (slide != NULL);
+
 		fs = slide->file2->data;
 		fs->file = g_strdup (text);
 		if (slide->file2->next != NULL)
@@ -3179,6 +3188,9 @@ gnome_bg_changes_with_time (GnomeBG *bg)
 	SlideShow *show;
 
 	g_return_val_if_fail (bg != NULL, FALSE);
+
+	if (!bg->filename)
+		return FALSE;
 
 	show = get_as_slideshow (bg, bg->filename);
 	if (show)


### PR DESCRIPTION
Fixes this warning

```
(cinnamon-settings-daemon:3556): CinnamonDesktop-CRITICAL **: handle_text: assertion 'parser->slides->tail != NULL' failed

(cinnamon-settings-daemon:3556): CinnamonDesktop-CRITICAL **: handle_text: assertion 'parser->slides->tail != NULL' failed

(cinnamon-settings-daemon:3556): CinnamonDesktop-CRITICAL **: handle_text: assertion 'parser->slides->tail != NULL' failed

(cinnamon-settings-daemon:3556): CinnamonDesktop-CRITICAL **: handle_text: assertion 'parser->slides->tail != NULL' failed

(cinnamon-settings-daemon:3556): CinnamonDesktop-CRITICAL **: handle_text: assertion 'parser->slides->tail != NULL' failed
```

Pull origin is from mate-desktop