### PR TITLE
thumbnail: Fix a code path where the mutex is never unlocked

### DIFF
--- a/libcinnamon-desktop/gnome-desktop-thumbnail.c
+++ b/libcinnamon-desktop/gnome-desktop-thumbnail.c
@@ -783,10 +783,11 @@ external_thumbnailers_disabled_changed_cb (GSettings                    *setting
 
   g_mutex_lock (&priv->lock);
 
-  if (priv->disabled)
-    return;
-  g_strfreev (priv->disabled_types);
-  priv->disabled_types = g_settings_get_strv (priv->settings, "disable");
+  if (!priv->disabled)
+    {
+      g_strfreev (priv->disabled_types);
+      priv->disabled_types = g_settings_get_strv (priv->settings, "disable");
+    }
 
   g_mutex_unlock (&priv->lock);
 }


### PR DESCRIPTION
taken from
https://git.gnome.org/browse/gnome-desktop/commit/?id=5b28350d3229d36d7c64084e52f5a40ee5903723