### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,13 +1,40 @@
 #!/bin/sh
+# Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="cinnamon-desktop"
+cd $srcdir
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME Git (or from"
-    echo "your OS vendor's package manager)."
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
-USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh
+
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
+fi
+
+aclocal --install || exit 1
+glib-gettextize --force --copy || exit 1
+gtkdocize --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,15 @@
 
 AC_INIT(cinnamon-desktop, 3.0.2)
+AX_IS_RELEASE([git-directory])
 AC_CONFIG_SRCDIR(libcinnamon-desktop)
 
-AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz tar-ustar])
+AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz tar-ustar subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CONFIG_HEADERS([config.h])
 
 AC_CONFIG_MACRO_DIR([m4])
+AC_SUBST([ACLOCAL_AMFLAGS], ["-I $ac_macro_dir \${ACLOCAL_FLAGS}"])
 
 # Before making a release, the LT_VERSION string should be modified.
 # The string is of the form C:R:A.
@@ -28,8 +30,7 @@ IT_PROG_INTLTOOL([0.40.6])
 AC_PROG_CC
 PKG_PROG_PKG_CONFIG
 
-GNOME_COMPILE_WARNINGS([maximum])
-GNOME_MAINTAINER_MODE_DEFINES
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
 
 AC_ARG_ENABLE(deprecation_flags,
               [AC_HELP_STRING([--enable-deprecation-flags],
@@ -84,6 +85,7 @@ PKG_CHECK_MODULES(XLIB, x11,
      AC_PATH_XTRA
      if test "x$no_x" = xyes; then
        AC_MSG_ERROR("no (requires X development libraries)")
+dnl "
      else
        XLIB_LIBS="$X_PRE_LIBS $X_LIBS -lX11 $X_EXTRA_LIBS"
        XLIB_CFLAGS=$X_CFLAGS

--- a/libcinnamon-desktop/Makefile.am
+++ b/libcinnamon-desktop/Makefile.am
@@ -6,6 +6,7 @@ lib_LTLIBRARIES = libcinnamon-desktop.la
 AM_CPPFLAGS =							\
 	-I$(top_srcdir)						\
 	-I$(srcdir)/libgsystem					\
+	$(WARN_CFLAGS)
 	$(CINNAMON_DESKTOP_CFLAGS)					\
 	$(XLIB_CFLAGS)						\
 	-DG_LOG_DOMAIN=\"CinnamonDesktop\"				\
@@ -14,10 +15,17 @@ AM_CPPFLAGS =							\
 	-DXKB_BASE=\""$(XKB_BASE)"\"				\
 	$(DISABLE_DEPRECATED_CFLAGS)
 
-AM_CFLAGS = $(WARN_CFLAGS)
+AM_CFLAGS = $(WARN_CFLAGS) $(CINNAMON_DESKTOP_CFLAGS) \
+	    $(XLIB_CFLAGS) \
+	    -DG_LOG_DOMAIN=\"CinnamonDesktop\" \
+	    -DGNOMELOCALEDIR=\""$(prefix)/$(DATADIRNAME)/locale\"" \
+	    -DPNP_IDS=\""$(PNP_IDS)"\" \
+	    -DXKB_BASE=\""$(XKB_BASE)"\" \
+	    $(DISABLE_DEPRECATED_CFLAGS)
+
 
 libgsystem_srcpath := libgsystem
-libgsystem_cflags = $(CINNAMON_DESKTOP_CFLAGS)
+libgsystem_cflags = $(WARN_CFLAGS) $(CINNAMON_DESKTOP_CFLAGS)
 libgsystem_libs = $(CINNAMON_DESKTOP_LIBS)
 include libgsystem/Makefile-libgsystem.am
 
@@ -93,18 +101,18 @@ INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 if HAVE_INTROSPECTION
 
 
-CDesktopEnums_3_0_gir_CFLAGS = -I$(srcdir)
+CDesktopEnums_3_0_gir_CFLAGS = $(WARN_CFLAGS) -I$(srcdir)
 CDesktopEnums_3_0_gir_FILES = cdesktop-enums.h
-CDesktopEnums_3_0_gir_SCANNERFLAGS = --header-only --identifier-prefix=CDesktop
+CDesktopEnums_3_0_gir_SCANNERFLAGS = $(WARN_SCANNERFLAGS) --header-only --identifier-prefix=CDesktop
 INTROSPECTION_GIRS += CDesktopEnums-3.0.gir
 CinnamonDesktop-3.0.gir: libcinnamon-desktop.la
 CinnamonDesktop_3_0_gir_INCLUDES = GObject-2.0 Gtk-3.0
 CinnamonDesktop_3_0_gir_PACKAGES = gdk-pixbuf-2.0 glib-2.0 gobject-2.0 gio-2.0 gtk+-3.0
 CinnamonDesktop_3_0_gir_EXPORT_PACKAGES = cinnamon-desktop
-CinnamonDesktop_3_0_gir_CFLAGS = -DGNOME_DESKTOP_USE_UNSTABLE_API -I$(top_srcdir)
+CinnamonDesktop_3_0_gir_CFLAGS = $(WARN_CFLAGS) -DGNOME_DESKTOP_USE_UNSTABLE_API -I$(top_srcdir)
 CinnamonDesktop_3_0_gir_LIBS = libcinnamon-desktop.la
 CinnamonDesktop_3_0_gir_FILES = $(introspection_sources) $(libcinnamon_desktop_HEADERS)
-CinnamonDesktop_3_0_gir_SCANNERFLAGS = --identifier-prefix=Gnome --symbol-prefix=gnome_
+CinnamonDesktop_3_0_gir_SCANNERFLAGS = $(WARN_SCANNERFLAGS) --identifier-prefix=Gnome --symbol-prefix=gnome_
 INTROSPECTION_SCANNER_ARGS += $(patsubst %,--c-include='libcinnamon-desktop/%',$(libcinnamon_desktop_HEADERS))
 INTROSPECTION_GIRS += CinnamonDesktop-3.0.gir
 

--- a/libcvc/Makefile.am
+++ b/libcvc/Makefile.am
@@ -58,9 +58,9 @@ INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 
 Cvc-1.0.gir: libcvc.la
 Cvc_1_0_gir_INCLUDES = GObject-2.0 Gio-2.0
-Cvc_1_0_gir_CFLAGS = $(INCLUDES) -I$(top_srcdir)/libcvc -DWITH_INTROSPECTION
+Cvc_1_0_gir_CFLAGS = $(WARN_CFLAGS) $(INCLUDES) -I$(top_srcdir)/libcvc -DWITH_INTROSPECTION
 Cvc_1_0_gir_LIBS = libcvc.la
-Cvc_1_0_gir_SCANNERFLAGS = --identifier-prefix=Gvc --symbol-prefix=gvc_
+Cvc_1_0_gir_SCANNERFLAGS = $(WARN_SCANNERFLAGS) --identifier-prefix=Gvc --symbol-prefix=gvc_
 Cvc_1_0_gir_FILES = $(libcvc_la_gir_sources) $(libcvc_HEADERS)
 INTROSPECTION_GIRS = Cvc-1.0.gir
 


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration

Please note that this still depends on gnome-common.