### PR TITLE
Fix includes for libcvc

### DIFF
--- a/libcvc/cvc.pc.in
+++ b/libcvc/cvc.pc.in
@@ -8,4 +8,4 @@ Description: Utility library for volume control (based on gvc)
 Requires: gio-2.0 libpulse libpulse-mainloop-glib gobject-2.0
 Version: @VERSION@
 Libs: -L${libdir} -lcvc
-Cflags: -I${includedir}/cvc
+Cflags: -I${includedir}/cinnamon-desktop/libcvc


### PR DESCRIPTION
```
'test-media-keys.c' || echo './'`test-media-keys.c
cc1: warning: /usr/include/cvc: No such file or directory [-Wmissing-include-dirs]
```