### PR TITLE
Update pam config for multi-distro compatibility

### DIFF
--- a/data/cinnamon-desktop
+++ b/data/cinnamon-desktop
@@ -1,12 +1,12 @@
 #%PAM-1.0
 
-# Fedora Core
-auth     [success=done ignore=ignore default=bad] pam_selinux_permit.so
-session    include      system-auth
+# Fedora & Arch
+-auth      sufficient   pam_selinux_permit.so
 auth       include      system-auth
 auth       optional     pam_gnome_keyring.so
 account    include      system-auth
 password   include      system-auth
+session    include      system-auth
 
 # SuSE/Novell
 #auth       include      common-auth


### PR DESCRIPTION
A change was made to the pam config file in be51f074f7316195ba376962d52746310ecb99e3 that effectively breaks authorization in cinnamon-screensaver for non Fedora users. The default config should work out-of-the-box on more distros than just Fedora. This change improves cross-distro compatibility by making sure auth doesn't fail just because `pam_selinux_permit.so` is not present on the system. Instead, the auth process will continue trying the remaining modules listed.

Fixes Antergos/antergos-packages#144

#### Reference: http://wpollock.com/AUnix2/PAM-Help.htm
>A missing module acts like a “fail”, and the error is logged (via the system logging daemon, usually syslog).
>
>If a line in the configuration file starts with a dash, the error isn't logged.  This can be useful for modules that may not be present, for example, a module for fingerprint authentication may not be present, but if it is, it should be used.
>
>To prevent authentication failure when a module is missing, such modules should be used with sufficient rather than required, such as:
>
>-auth   sufficient   pam_fingerprintd.so