### PR TITLE
schemas: Add some new keys for High Contrast

### DIFF
--- a/schemas/org.cinnamon.desktop.interface.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.interface.gschema.xml.in.in
@@ -103,11 +103,25 @@
         Icon theme to use for the panel, nautilus etc.
       </_description>
     </key>
+    <key name="icon-theme-backup" type="s">
+      <default>'gnome'</default>
+      <_summary>Icon Theme Backup</_summary>
+      <_description>
+        This is used to store the current icon theme when high contrast is enabled.
+      </_description>
+    </key>
     <key name="gtk-theme" type="s">
       <default>'Adwaita'</default>
       <_summary>Gtk+ Theme</_summary>
       <_description>
         Basename of the default theme used by gtk+.
+      </_description>
+    </key>
+    <key name="gtk-theme-backup" type="s">
+      <default>'Adwaita'</default>
+      <_summary>Gtk+ Theme Backup</_summary>
+      <_description>
+        This is used to store the current theme when enabling high contrast.
       </_description>
     </key>
     <key name="gtk-key-theme" type="s">

--- a/schemas/org.cinnamon.desktop.wm.preferences.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.wm.preferences.gschema.xml.in.in
@@ -222,6 +222,13 @@
         and so forth.
       </_description>
     </key>
+    <key name="theme-backup" type="s">
+      <default>'Adwaita'</default>
+      <_summary>Current theme backup</_summary>
+      <_description>
+        This is used to store the current theme when enabling high contrast.
+      </_description>
+    </key>
     <key name="titlebar-uses-system-font" type="b">
       <default>false</default>
       <_summary>Use standard system font in window titles</_summary>


### PR DESCRIPTION
We need a couple of new keys to store the original themes in use so we can get
back to them when disabling High Contrast