### PR TITLE
gvc-mixer-control: fix double-free when setting headset

### DIFF
--- a/libcvc/gvc-mixer-control.c
+++ b/libcvc/gvc-mixer-control.c
@@ -2099,7 +2099,7 @@ sink_info_cb (pa_context         *c,
         int j;
         const char *s;
 
-        if (eol) {
+        if (eol != 0) {
                 port_status_data_free (data);
                 return;
         }
@@ -2122,7 +2122,6 @@ sink_info_cb (pa_context         *c,
 
         o = pa_context_set_sink_port_by_index (c, i->index, s, NULL, NULL);
         g_clear_pointer (&o, pa_operation_unref);
-        port_status_data_free (data);
 }
 
 static void
@@ -2136,7 +2135,7 @@ source_info_cb (pa_context           *c,
         int j;
         const char *s;
 
-        if (eol) {
+        if (eol != 0) {
                 port_status_data_free (data);
                 return;
         }
@@ -2158,7 +2157,6 @@ source_info_cb (pa_context           *c,
 
         o = pa_context_set_source_port_by_index(c, i->index, s, NULL, NULL);
         g_clear_pointer (&o, pa_operation_unref);
-        port_status_data_free (data);
 }
 
 static void


### PR DESCRIPTION
https://git.gnome.org/browse/libgnome-volume-control/commit/?id=a28e23d9006a32c8982ad8bda11fec131c6b36e8
https://git.gnome.org/browse/libgnome-volume-control/commit/?id=25bf3ed75fa604fa73e8b25241119a993fc659d6

No regressions I can see on speakers, headphones, simple headset. No messages in log. Laptop.  Could probably do with a quick once-over by someone with more exotic kit.