### PR TITLE
Notifications: Add bottom position option

### DIFF
--- a/schemas/org.cinnamon.desktop.notifications.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.notifications.gschema.xml.in.in
@@ -28,6 +28,10 @@
       <default>true</default>
       <_summary>Whether notifications are to be displayed</_summary>
     </key>
+    <key type="b" name="bottom-notifications">
+      <default>false</default>
+      <_summary>Whether notifications are displayed on the bottom side of the screen</_summary>
+    </key>
   </schema>
 </schemalist>
 


### PR DESCRIPTION
This adds an option to move the notification popup to the bottom of the screen.