### PR TITLE
gnome-bg: proper fix for NULL gvariant unref

### DIFF
--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -377,9 +377,9 @@ set_user_bg_with_display_manager (const gchar *obj_path,
     g_clear_error (&error);
 
     return FALSE;
-  } else {
-    g_variant_unref (ret);
   }
+
+  g_variant_unref (ret);
 
   g_debug ("Background set via org.freedesktop.DisplayManager.AccountsService BackgroundFile");
 
@@ -431,9 +431,10 @@ set_user_bg_with_accounts_service (const gchar *obj_path,
              error->message);
 
     g_clear_error (&error);
-  } else {
-    g_variant_unref (ret);
+    return;
   }
+
+  g_variant_unref (ret);
 
   g_debug ("Background set via org.freedesktop.AccountsService.User SetBackgroundFile");
 }


### PR DESCRIPTION
Move the unref after the error check and return on error.

The _with_display_manager variant of this function didn't actually
need any changes since we already did this there.

fixes: 1fcdab4c07