### PR TITLE
Fix pkgconfig version and fix spacing

### DIFF
--- a/libcinnamon-desktop/meson.build
+++ b/libcinnamon-desktop/meson.build
@@ -66,8 +66,8 @@ install_headers(
 
 pkgconfig.generate(
   name: 'cinnamon-desktop',
-  description: 'Utility library for loading.desktop files',
-  version: LT_VERSION,
+  description: 'Utility library for loading .desktop files',
+  version: meson.project_version(),
   requires: [ 'gtk+-3.0', ],
   requires_private: [ 'xkbfile', ],
   libraries: libcinnamon_desktop,


### PR DESCRIPTION
In autotools build, pkgconfig version was the project version.