### PR TITLE
Update style of meson build options

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,8 +8,8 @@ override_dh_auto_configure:
 	meson debian/build \
 		--prefix=/usr \
 		--buildtype=plain \
-		-Dpnp-ids-path=/usr/share/hwdata/pnp.ids \
-		-Ddeprecation-flags=false
+		-Dpnp_ids=/usr/share/hwdata/pnp.ids \
+		-Ddeprecation_warnings=false
 
 override_dh_auto_build:
 	ninja -C debian/build

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ gnome     = import('gnome')
 
 cc                = meson.get_compiler('c')
 
-if not get_option('deprecation-flags')
+if not get_option('deprecation_warnings')
   add_global_arguments('-Wno-deprecated-declarations', language: 'c')
 endif
 
@@ -66,7 +66,7 @@ cvc_deps = cinnamon_deps + [
   gobject
 ]
 
-use_alsa = get_option('use-alsa')
+use_alsa = get_option('alsa')
 
 if use_alsa
   cvc_deps += dependency('alsa')
@@ -77,7 +77,7 @@ xkb_base = xkbconf.get_pkgconfig_variable('xkb_base')
 # Path to the pnp.ids file -- to know if we use one shipped with another
 # package, or an internal file
 
-pnp_ids_path = get_option('pnp-ids-path')
+pnp_ids_path = get_option('pnp_ids')
 pnp_ids_install_internal = (pnp_ids_path == '')
 
 if pnp_ids_install_internal
@@ -148,8 +148,8 @@ message('\n'.join([
   '        source code location:         ' + meson.source_root(),
   '        compiler:                     ' + cc.get_id(),
   '        debugging support:            ' + get_option('buildtype'),
-  '        Use *_DISABLE_DEPRECATED:     @0@'.format(get_option('deprecation-flags')),
+  '        Use *_DISABLE_DEPRECATED:     @0@'.format(get_option('deprecation_warnings')),
   '        Use PNP files:                ' + pnp_message,
-  '        Use Alsa:                     ' + '@0@'.format(use_alsa),
+  '        Use ALSA:                     ' + '@0@'.format(use_alsa),
   '',
 ]))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,6 @@
-option('deprecation-flags', type: 'boolean', value: true)
-option('pnp-ids-path',      type: 'string',  value: '')
-option('use-alsa',          type: 'boolean', value: false)
+option('deprecation_warnings', type: 'boolean', value: false,
+       description: 'Show compiler warnings about deprecated features')
+option('pnp_ids', type: 'string',  value: '',
+       description: 'Specify the path to pnp.ids (default is an internal copy)')
+option('alsa', type: 'boolean', value: false,
+       description: 'ALSA support')


### PR DESCRIPTION
Changed the name of deprecated-flags build option to match the one
in nemo and set it to false by default like it was before the meson port.
Also added descriptions. Following the style guidelines here:
https://wiki.gnome.org/Initiatives/GnomeGoals/MesonPorting