### PR TITLE
default-applications.gschema.xml: Define schema for a default calculator

### DIFF
--- a/schemas/org.cinnamon.desktop.default-applications.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.default-applications.gschema.xml.in.in
@@ -2,6 +2,7 @@
   <schema id="org.cinnamon.desktop.default-applications" path="/org/cinnamon/desktop/applications/">
     <child name="office" schema="org.cinnamon.desktop.default-applications.office"/>
     <child name="terminal" schema="org.cinnamon.desktop.default-applications.terminal"/>
+    <child name="calculator" schema="org.cinnamon.desktop.default-applications.calculator"/>
   </schema>
   <schema id="org.cinnamon.desktop.default-applications.office" path="/org/cinnamon/desktop/applications/office/">
     <child name="calendar" schema="org.cinnamon.desktop.default-applications.office.calendar"/>
@@ -53,6 +54,22 @@
       <_description>
         Argument used to execute programs in the terminal defined by the 
         'exec' key.
+      </_description>
+    </key>
+  </schema>
+  <schema id="org.cinnamon.desktop.default-applications.calculator" path="/org/cinnamon/desktop/applications/calculator/">
+    <key name="exec" type="s">
+      <default>'gnome-calculator'</default>
+      <_summary>Default calculator</_summary>
+      <_description>
+        Default calculator application.
+      </_description>
+    </key>
+    <key name="needs-term" type="b">
+      <default>false</default>
+      <_summary>Calculator needs terminal</_summary>
+      <_description>
+        Whether the default calculator application needs a terminal to run.
       </_description>
     </key>
   </schema>


### PR DESCRIPTION
* Defines a schema that allows users to specify a default calculator application.
* Default initialized to 'gnome-calculator'.
* By itself, this PR does not change much. However, it allows for other relevant PRs to act on the existence of this schema.
  * Will open PR at [linuxmint/Cinnamon](https://github.com/linuxmint/Cinnamon) to open a PR to expose a SettingsWidget() in [cs_default.py](https://github.com/linuxmint/Cinnamon/blob/master/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py) to control the schema
  * Will open PR at [linuxmint/cinnamon-settings-daemon](https://github.com/linuxmint/cinnamon-settings-daemon) to update [csd-media-key-manager.c](https://github.com/linuxmint/cinnamon-settings-daemon/blob/master/plugins/media-keys/csd-media-keys-manager.c) to honor the schema as opposed to the following behavior:
      1. Execute 'gnome-calculator', if available.
      2. If 'gnome-calculator' is not available, execute 'galculator', if available.
      3. If 'galculator' is not available, execute 'mate-calc', if available.
      4. If 'mate-calc' is not available, silently do nothing.