### PR TITLE
Meson deprecations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 
 # https://github.com/linuxmint/cinnamon-desktop
 project('cinnamon-desktop', 'c', version: '4.0.1',
-  meson_version: '>=0.37.0'
+  meson_version: '>=0.41.0'
 )
 
 # Before making a release, the LT_VERSION string should be modified.

--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -42,7 +42,7 @@ foreach schema : desktop_gschemas
     command : ['intltool-merge', '--quiet', '--xml-style', '--utf8', po_subdir, '@INPUT@', '@OUTPUT@'],
     install : true,
     install_dir : join_paths(get_option('datadir'), 'glib-2.0', 'schemas'),
-    build_always : true,
+    build_by_default : true,
   )
 
 endforeach


### PR DESCRIPTION
Bump the minimum meson version to something that we needed anyway, and return to using build_by_default which was removed in 05bd02d5af851bab6c83d0969a2dad3a94582b63 due to version pinning.