### PR TITLE
Fix unused GIR transfer notation on integer values

### DIFF
--- a/libcvc/gvc-mixer-stream.c
+++ b/libcvc/gvc-mixer-stream.c
@@ -166,7 +166,7 @@ gvc_mixer_stream_get_channel_map (GvcMixerStream *stream)
  * gvc_mixer_stream_get_volume:
  * @stream:
  *
- * Returns: (type guint32) (transfer none):
+ * Returns: (type guint32):
  */
 pa_volume_t
 gvc_mixer_stream_get_volume (GvcMixerStream *stream)
@@ -494,7 +494,7 @@ gvc_mixer_stream_set_sysfs_path (GvcMixerStream *stream,
  * gvc_mixer_stream_get_base_volume:
  * @stream:
  *
- * Returns: (type guint32) (transfer none):
+ * Returns: (type guint32):
  */
 pa_volume_t
 gvc_mixer_stream_get_base_volume (GvcMixerStream *stream)


### PR DESCRIPTION
Based on https://github.com/GNOME/libgnome-volume-control/commit/9a2996b3626713df80e62b42721f94a5e20e2958