### PR TITLE
Fetch clock formats using LC_TIME (as opposed to LANGUAGE)

### DIFF
--- a/libcinnamon-desktop/gnome-wall-clock.h
+++ b/libcinnamon-desktop/gnome-wall-clock.h
@@ -68,6 +68,9 @@ gchar *           gnome_wall_clock_get_clock_for_format (GnomeWallClock *clock,
 GnomeWallClock *  gnome_wall_clock_new           (void);
 gboolean          gnome_wall_clock_set_format_string (GnomeWallClock *clock,
                                                       const gchar    *format_string);
+gchar *           gnome_wall_clock_lctime_format (const gchar * gettext_domain,
+                                                  const gchar * format_string);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
**Problem**

When we use strftime parts of the date (day and month names) are translated according to LC_TIME.

But when we fetch the clock format (which is translated by our translators), we use gettext and that uses LANGUAGE, not LC_TIME. If LANGUAGE and LC_TIME are different we then end up with broken clocks which mix both languages.

Here's a python script (test-cdesktop.py) to illustrate it:

```
#!/usr/bin/python3

import gi
gi.require_version('CinnamonDesktop', '3.0')
from gi.repository import CinnamonDesktop

clock = CinnamonDesktop.WallClock()
print(clock.get_clock().capitalize())
```

Run that with an English LANGUAGE and a Spanish LC_TIME and you get a broken clock:

```
clem@airtop ~/Desktop $ LANGUAGE=es_ES.UTF-8 LC_TIME=en_US.UTF-8 ./test-cdesktop.py
Friday,  4 de october, 14:38
```

English names, Spanish format.
It should be English names and format, both according to LC_TIME.

**Solution**

GNOME implemented a fix in their clock at https://gitlab.gnome.org/GNOME/gnome-desktop/commit/0f3de28f94801fc7d042e3dd53f8fb52b4f1a162. I don't know if their fix works in GNOME, but it has no effect here when ported to our library.

Working on prototypes we also established that setenv() could only be called once and wasn't reliable.

dcgettext can be used with LC_TIME instead of LC_MESSAGES.. but that doesn't do what we want... our translations are in LC_MESSAGES/ not in LC_TIME/ on the fs.. so that does the opposite of what we want. We want to fetch LC_MESSAGES according to the locale defined by LC_TIME.

This PR solves the problem by temporarily switching the LANGUAGE environment variable and assigning it to the value of LC_TIME.

This results in clocks being formatted correctly according to LC_TIME:

```
clem@airtop ~/Desktop $ LANGUAGE=es_ES.UTF-8 LC_TIME=en_US.UTF-8 ./test-cdesktop.py
Friday october  4, 14:54
clem@airtop ~/Desktop $ LANGUAGE=es_ES.UTF-8 LC_TIME=fr_FR.UTF-8 ./test-cdesktop.py
Vendredi  4 octobre, 14:54
clem@airtop ~/Desktop $ LANGUAGE=en_US.UTF-8 LC_TIME=es_ES.UTF-8 ./test-cdesktop.py
Viernes,  4 de octubre, 14:54
```