### PR TITLE
Fix scale calculation for cinnamon-control-center's display panel

### DIFF
--- a/libcinnamon-desktop/gnome-rr-output-info.c
+++ b/libcinnamon-desktop/gnome-rr-output-info.c
@@ -40,7 +40,7 @@ gnome_rr_output_info_init (GnomeRROutputInfo *self)
     self->priv->name = NULL;
     self->priv->on = FALSE;
     self->priv->display_name = NULL;
-    self->priv->scale = 0;
+    self->priv->scale = 1;
 }
 
 static void


### PR DESCRIPTION
This fixes a bug with scale calculation for connected but disabled monitors. We don't want to calculate 1/(0/1) ever