### PR TITLE
Fixes for gnome-rr scaling

### DIFF
--- a/libcinnamon-desktop/gnome-rr-config.h
+++ b/libcinnamon-desktop/gnome-rr-config.h
@@ -159,6 +159,9 @@ void                gnome_rr_config_set_clone    (GnomeRRConfig  *configuration,
 guint               gnome_rr_config_get_base_scale (GnomeRRConfig *self);
 void                gnome_rr_config_set_base_scale (GnomeRRConfig *self,
                                                     guint base_scale);
+gboolean            gnome_rr_config_get_auto_scale (GnomeRRConfig *self);
+void                gnome_rr_config_set_auto_scale (GnomeRRConfig *self,
+                                                    gboolean       auto_scale);
 GnomeRROutputInfo **gnome_rr_config_get_outputs  (GnomeRRConfig  *configuration);
 
 char *gnome_rr_config_get_backup_filename (void);

--- a/libcinnamon-desktop/gnome-rr-private.h
+++ b/libcinnamon-desktop/gnome-rr-private.h
@@ -6,9 +6,9 @@
 #include <X11/extensions/Xrandr.h>
 
 #define MINIMUM_LOGICAL_SCALE_FACTOR 0.74f
-#define MAXIMUM_LOGICAL_SCALE_FACTOR 4.0f
+#define MAXIMUM_LOGICAL_SCALE_FACTOR 2.0f
 #define MINIMUM_GLOBAL_SCALE_FACTOR 1
-#define MAXIMUM_GLOBAL_SCALE_FACTOR 4
+#define MAXIMUM_GLOBAL_SCALE_FACTOR 2
 
 typedef struct ScreenInfo ScreenInfo;
 
@@ -83,6 +83,7 @@ struct GnomeRRConfigPrivate
   GnomeRRScreen *screen;
   GnomeRROutputInfo **outputs;
   guint base_scale;
+  gboolean auto_scale;
 };
 
 gboolean _gnome_rr_output_name_is_laptop (const char *name);

--- a/libcinnamon-desktop/gnome-rr.c
+++ b/libcinnamon-desktop/gnome-rr.c
@@ -2996,8 +2996,8 @@ gnome_rr_screen_calculate_best_global_scale (GnomeRRScreen *screen,
     }
 
     if (width_mm > 0 && height_mm > 0) {
-            dpi_x = (double) real_width * monitor_scale / (width_mm / 25.4);
-            dpi_y = (double) real_height * monitor_scale / (height_mm / 25.4);
+            dpi_x = (double) real_width / (width_mm / 25.4);
+            dpi_y = (double) real_height / (height_mm / 25.4);
             /* We don't completely trust these values so both must be high, and never pick higher ratio than
               2 automatically */
             if (dpi_x > HIDPI_LIMIT && dpi_y > HIDPI_LIMIT)

--- a/libcinnamon-desktop/gnome-rr.h
+++ b/libcinnamon-desktop/gnome-rr.h
@@ -145,7 +145,8 @@ gboolean        gnome_rr_screen_set_dpms_mode      (GnomeRRScreen         *scree
                                                     GnomeRRDpmsMode        mode,
                                                     GError              **error);
 guint             gnome_rr_screen_get_global_scale (GnomeRRScreen   *screen);
-void            gnome_rr_screen_set_global_scale   (GnomeRRScreen   *screen,
+guint             gnome_rr_screen_get_global_scale_setting (GnomeRRScreen   *screen);
+void            gnome_rr_screen_set_global_scale_setting (GnomeRRScreen   *screen,
                                                     guint            scale_factor);
 gboolean        gnome_rr_screen_get_use_upscaling  (GnomeRRScreen        *screen);
 float *         gnome_rr_screen_calculate_supported_scales (GnomeRRScreen     *screen,


### PR DESCRIPTION
Various changes for the cinnamon-control-center display module re-introducing 'automatic' ui scale.
see linuxmint/cinnamon-control-center#238