### PR TITLE
Changed setting from '-x' to '--'

### DIFF
--- a/schemas/org.cinnamon.desktop.default-applications.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.default-applications.gschema.xml.in.in
@@ -49,7 +49,7 @@
       </_description>
     </key>
     <key name="exec-arg" type="s">
-      <default>'-x'</default>
+      <default>'--'</default>
       <_summary>Exec Arguments</_summary>
       <_description>
         Argument used to execute programs in the terminal defined by the 


### PR DESCRIPTION
This PR is to update the exec-arg setting for gnome-terminal from '-x' to '--'