### PR TITLE
Bump meson version to 0.50.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 
 # https://github.com/linuxmint/cinnamon-desktop
 project('cinnamon-desktop', 'c', version: '4.6.4',
-  meson_version: '>=0.41.0'
+  meson_version: '>=0.50.0'
 )
 
 # Before making a release, the LT_VERSION string should be modified.


### PR DESCRIPTION
```
WARNING: Project specifies a minimum meson_version '>=0.41.0' but uses features which were added in newer versions:
 * 0.50.0: {'install arg in configure_file'}
```

Reason: ^

Focal repos are 0.53-2, Bionic 0.45, we were using 0.41