### PR TITLE
gnome-bg.c: don't decrement hour by 1 when parsing xml backgrounds

### DIFF
--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -3028,7 +3028,7 @@ handle_text (GMarkupParseContext *context,
 		parser->start_tm.tm_mday = parse_int (text);
 	}
 	else if (stack_is (parser, "hour", "starttime", "background", NULL)) {
-		parser->start_tm.tm_hour = parse_int (text) - 1;
+		parser->start_tm.tm_hour = parse_int (text);
 	}
 	else if (stack_is (parser, "minute", "starttime", "background", NULL)) {
 		parser->start_tm.tm_min = parse_int (text);


### PR DESCRIPTION
I've noticed that the times at which desktop background transitions take place are off by 1 hour compared to what is specified in the XML files. Increasing the value in the hour field by 1 fixed the issue.

I looked into why, and the culprit is that the value stored in the <hour> field is decremented by 1. Maybe someone assumed hours were being counted from 0 to 23.

Assuming that the code was forked from GNOME, I looked into gnome-desktop, and the issue is noted there, too. (https://gitlab.gnome.org/GNOME/gnome-backgrounds/-/issues/4), and the same fix as the one in this pull request is waiting to be merged (https://gitlab.gnome.org/GNOME/gnome-desktop/-/merge_requests/97).
