### PR TITLE
GVC: avoid deprecated g_type_class_add_private

### DIFF
--- a/libcvc/gvc-channel-map.c
+++ b/libcvc/gvc-channel-map.c
@@ -30,8 +30,6 @@
 #include "gvc-channel-map.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_CHANNEL_MAP_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_CHANNEL_MAP, GvcChannelMapPrivate))
-
 struct GvcChannelMapPrivate
 {
         pa_channel_map        pa_map;
@@ -51,7 +49,7 @@ static guint signals [LAST_SIGNAL] = { 0, };
 
 static void     gvc_channel_map_finalize   (GObject            *object);
 
-G_DEFINE_TYPE (GvcChannelMap, gvc_channel_map, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcChannelMap, gvc_channel_map, G_TYPE_OBJECT)
 
 guint
 gvc_channel_map_get_num_channels (const GvcChannelMap *map)
@@ -277,8 +275,6 @@ gvc_channel_map_class_init (GvcChannelMapClass *klass)
                               NULL, NULL,
                               g_cclosure_marshal_VOID__BOOLEAN,
                               G_TYPE_NONE, 1, G_TYPE_BOOLEAN);
-
-        g_type_class_add_private (klass, sizeof (GvcChannelMapPrivate));
 }
 
 void
@@ -305,7 +301,7 @@ gvc_channel_map_volume_changed (GvcChannelMap     *map,
 static void
 gvc_channel_map_init (GvcChannelMap *map)
 {
-        map->priv = GVC_CHANNEL_MAP_GET_PRIVATE (map);
+        map->priv = gvc_channel_map_get_instance_private (map);
         map->priv->pa_volume_is_set = FALSE;
 }
 

--- a/libcvc/gvc-mixer-card.c
+++ b/libcvc/gvc-mixer-card.c
@@ -34,8 +34,6 @@
 #include "gvc-mixer-card.h"
 #include "gvc-mixer-card-private.h"
 
-#define GVC_MIXER_CARD_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_CARD, GvcMixerCardPrivate))
-
 static guint32 card_serial = 1;
 
 struct GvcMixerCardPrivate
@@ -67,7 +65,7 @@ enum
 
 static void     gvc_mixer_card_finalize   (GObject            *object);
 
-G_DEFINE_TYPE (GvcMixerCard, gvc_mixer_card, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerCard, gvc_mixer_card, G_TYPE_OBJECT)
 
 static guint32
 get_next_card_serial (void)
@@ -509,14 +507,12 @@ gvc_mixer_card_class_init (GvcMixerCardClass *klass)
                                                               "Name of current profile for this card in human readable form",
                                                               NULL,
                                                               G_PARAM_READABLE));
-
-        g_type_class_add_private (klass, sizeof (GvcMixerCardPrivate));
 }
 
 static void
 gvc_mixer_card_init (GvcMixerCard *card)
 {
-        card->priv = GVC_MIXER_CARD_GET_PRIVATE (card);
+        card->priv = gvc_mixer_card_get_instance_private (card);
 }
 
 GvcMixerCard *

--- a/libcvc/gvc-mixer-control.c
+++ b/libcvc/gvc-mixer-control.c
@@ -50,8 +50,6 @@
 #include "gvc-mixer-control-private.h"
 #include "gvc-mixer-ui-device.h"
 
-#define GVC_MIXER_CONTROL_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_CONTROL, GvcMixerControlPrivate))
-
 #define RECONNECT_DELAY 5
 
 enum {
@@ -134,7 +132,7 @@ static guint signals [LAST_SIGNAL] = { 0, };
 
 static void     gvc_mixer_control_finalize   (GObject              *object);
 
-G_DEFINE_TYPE (GvcMixerControl, gvc_mixer_control, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerControl, gvc_mixer_control, G_TYPE_OBJECT)
 
 pa_context *
 gvc_mixer_control_get_pa_context (GvcMixerControl *control)
@@ -3671,14 +3669,13 @@ gvc_mixer_control_class_init (GvcMixerControlClass *klass)
                               NULL, NULL,
                               g_cclosure_marshal_VOID__UINT,
                               G_TYPE_NONE, 1, G_TYPE_UINT);
-        g_type_class_add_private (klass, sizeof (GvcMixerControlPrivate));
 }
 
 
 static void
 gvc_mixer_control_init (GvcMixerControl *control)
 {
-        control->priv = GVC_MIXER_CONTROL_GET_PRIVATE (control);
+        control->priv = gvc_mixer_control_get_instance_private (control);
 
         control->priv->pa_mainloop = pa_glib_mainloop_new (g_main_context_default ());
         g_assert (control->priv->pa_mainloop);

--- a/libcvc/gvc-mixer-event-role.c
+++ b/libcvc/gvc-mixer-event-role.c
@@ -34,8 +34,6 @@
 #include "gvc-mixer-stream-private.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_MIXER_EVENT_ROLE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_EVENT_ROLE, GvcMixerEventRolePrivate))
-
 struct GvcMixerEventRolePrivate
 {
         char          *device;
@@ -49,7 +47,7 @@ enum
 
 static void     gvc_mixer_event_role_finalize   (GObject            *object);
 
-G_DEFINE_TYPE (GvcMixerEventRole, gvc_mixer_event_role, GVC_TYPE_MIXER_STREAM)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerEventRole, gvc_mixer_event_role, GVC_TYPE_MIXER_STREAM)
 
 static gboolean
 update_settings (GvcMixerEventRole *role,
@@ -178,14 +176,12 @@ gvc_mixer_event_role_class_init (GvcMixerEventRoleClass *klass)
                                                               "Device",
                                                               NULL,
                                                               G_PARAM_READWRITE|G_PARAM_CONSTRUCT));
-
-        g_type_class_add_private (klass, sizeof (GvcMixerEventRolePrivate));
 }
 
 static void
 gvc_mixer_event_role_init (GvcMixerEventRole *event_role)
 {
-        event_role->priv = GVC_MIXER_EVENT_ROLE_GET_PRIVATE (event_role);
+        event_role->priv = gvc_mixer_event_role_get_instance_private (event_role);
 
 }
 

--- a/libcvc/gvc-mixer-sink-input.c
+++ b/libcvc/gvc-mixer-sink-input.c
@@ -33,8 +33,6 @@
 #include "gvc-mixer-stream-private.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_MIXER_SINK_INPUT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_SINK_INPUT, GvcMixerSinkInputPrivate))
-
 struct GvcMixerSinkInputPrivate
 {
         gpointer dummy;
@@ -42,7 +40,7 @@ struct GvcMixerSinkInputPrivate
 
 static void     gvc_mixer_sink_input_finalize   (GObject                *object);
 
-G_DEFINE_TYPE (GvcMixerSinkInput, gvc_mixer_sink_input, GVC_TYPE_MIXER_STREAM)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerSinkInput, gvc_mixer_sink_input, GVC_TYPE_MIXER_STREAM)
 
 static gboolean
 gvc_mixer_sink_input_push_volume (GvcMixerStream *stream, gpointer *op)
@@ -114,14 +112,12 @@ gvc_mixer_sink_input_class_init (GvcMixerSinkInputClass *klass)
 
         stream_class->push_volume = gvc_mixer_sink_input_push_volume;
         stream_class->change_is_muted = gvc_mixer_sink_input_change_is_muted;
-
-        g_type_class_add_private (klass, sizeof (GvcMixerSinkInputPrivate));
 }
 
 static void
 gvc_mixer_sink_input_init (GvcMixerSinkInput *sink_input)
 {
-        sink_input->priv = GVC_MIXER_SINK_INPUT_GET_PRIVATE (sink_input);
+        sink_input->priv = gvc_mixer_sink_input_get_instance_private (sink_input);
 }
 
 static void

--- a/libcvc/gvc-mixer-sink.c
+++ b/libcvc/gvc-mixer-sink.c
@@ -33,8 +33,6 @@
 #include "gvc-mixer-stream-private.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_MIXER_SINK_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_SINK, GvcMixerSinkPrivate))
-
 struct GvcMixerSinkPrivate
 {
         gpointer dummy;
@@ -42,7 +40,7 @@ struct GvcMixerSinkPrivate
 
 static void     gvc_mixer_sink_finalize   (GObject           *object);
 
-G_DEFINE_TYPE (GvcMixerSink, gvc_mixer_sink, GVC_TYPE_MIXER_STREAM)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerSink, gvc_mixer_sink, GVC_TYPE_MIXER_STREAM)
 
 static gboolean
 gvc_mixer_sink_push_volume (GvcMixerStream *stream, gpointer *op)
@@ -143,14 +141,12 @@ gvc_mixer_sink_class_init (GvcMixerSinkClass *klass)
         stream_class->push_volume = gvc_mixer_sink_push_volume;
         stream_class->change_port = gvc_mixer_sink_change_port;
         stream_class->change_is_muted = gvc_mixer_sink_change_is_muted;
-
-        g_type_class_add_private (klass, sizeof (GvcMixerSinkPrivate));
 }
 
 static void
 gvc_mixer_sink_init (GvcMixerSink *sink)
 {
-        sink->priv = GVC_MIXER_SINK_GET_PRIVATE (sink);
+        sink->priv = gvc_mixer_sink_get_instance_private (sink);
 }
 
 static void

--- a/libcvc/gvc-mixer-source-output.c
+++ b/libcvc/gvc-mixer-source-output.c
@@ -33,8 +33,6 @@
 #include "gvc-mixer-stream-private.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_MIXER_SOURCE_OUTPUT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_SOURCE_OUTPUT, GvcMixerSourceOutputPrivate))
-
 struct GvcMixerSourceOutputPrivate
 {
         gpointer dummy;
@@ -42,7 +40,7 @@ struct GvcMixerSourceOutputPrivate
 
 static void     gvc_mixer_source_output_finalize   (GObject            *object);
 
-G_DEFINE_TYPE (GvcMixerSourceOutput, gvc_mixer_source_output, GVC_TYPE_MIXER_STREAM)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerSourceOutput, gvc_mixer_source_output, GVC_TYPE_MIXER_STREAM)
 
 static gboolean
 gvc_mixer_source_output_push_volume (GvcMixerStream *stream, gpointer *op)
@@ -114,14 +112,12 @@ gvc_mixer_source_output_class_init (GvcMixerSourceOutputClass *klass)
 
         stream_class->push_volume = gvc_mixer_source_output_push_volume;
         stream_class->change_is_muted = gvc_mixer_source_output_change_is_muted;
-
-        g_type_class_add_private (klass, sizeof (GvcMixerSourceOutputPrivate));
 }
 
 static void
 gvc_mixer_source_output_init (GvcMixerSourceOutput *source_output)
 {
-        source_output->priv = GVC_MIXER_SOURCE_OUTPUT_GET_PRIVATE (source_output);
+        source_output->priv = gvc_mixer_source_output_get_instance_private (source_output);
 
 }
 

--- a/libcvc/gvc-mixer-source.c
+++ b/libcvc/gvc-mixer-source.c
@@ -33,8 +33,6 @@
 #include "gvc-mixer-stream-private.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_MIXER_SOURCE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_SOURCE, GvcMixerSourcePrivate))
-
 struct GvcMixerSourcePrivate
 {
         gpointer dummy;
@@ -42,7 +40,7 @@ struct GvcMixerSourcePrivate
 
 static void     gvc_mixer_source_finalize   (GObject            *object);
 
-G_DEFINE_TYPE (GvcMixerSource, gvc_mixer_source, GVC_TYPE_MIXER_STREAM)
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerSource, gvc_mixer_source, GVC_TYPE_MIXER_STREAM)
 
 static gboolean
 gvc_mixer_source_push_volume (GvcMixerStream *stream, gpointer *op)
@@ -143,14 +141,12 @@ gvc_mixer_source_class_init (GvcMixerSourceClass *klass)
         stream_class->push_volume = gvc_mixer_source_push_volume;
         stream_class->change_is_muted = gvc_mixer_source_change_is_muted;
         stream_class->change_port = gvc_mixer_source_change_port;
-
-        g_type_class_add_private (klass, sizeof (GvcMixerSourcePrivate));
 }
 
 static void
 gvc_mixer_source_init (GvcMixerSource *source)
 {
-        source->priv = GVC_MIXER_SOURCE_GET_PRIVATE (source);
+        source->priv = gvc_mixer_source_get_instance_private (source);
 }
 
 static void

--- a/libcvc/gvc-mixer-stream.c
+++ b/libcvc/gvc-mixer-stream.c
@@ -33,8 +33,6 @@
 #include "gvc-mixer-stream-private.h"
 #include "gvc-channel-map-private.h"
 
-#define GVC_MIXER_STREAM_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GVC_TYPE_MIXER_STREAM, GvcMixerStreamPrivate))
-
 static guint32 stream_serial = 1;
 
 struct GvcMixerStreamPrivate
@@ -94,7 +92,7 @@ static guint signals [LAST_SIGNAL] = { 0, };
 
 static void     gvc_mixer_stream_finalize   (GObject            *object);
 
-G_DEFINE_ABSTRACT_TYPE (GvcMixerStream, gvc_mixer_stream, G_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (GvcMixerStream, gvc_mixer_stream, G_TYPE_OBJECT)
 
 static void
 free_port (GvcMixerStreamPort *p)
@@ -1165,13 +1163,12 @@ gvc_mixer_stream_class_init (GvcMixerStreamClass *klass)
                               g_cclosure_marshal_VOID__VOID,
                               G_TYPE_NONE, 0, G_TYPE_NONE);
 
-       g_type_class_add_private (klass, sizeof (GvcMixerStreamPrivate));
 }
 
 static void
 gvc_mixer_stream_init (GvcMixerStream *stream)
 {
-        stream->priv = GVC_MIXER_STREAM_GET_PRIVATE (stream);
+        stream->priv = gvc_mixer_stream_get_instance_private (stream);
 }
 
 static void

--- a/libcvc/gvc-mixer-ui-device.c
+++ b/libcvc/gvc-mixer-ui-device.c
@@ -23,8 +23,6 @@
 #include "gvc-mixer-ui-device.h"
 #include "gvc-mixer-card.h"
 
-#define GVC_MIXER_UI_DEVICE_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), GVC_TYPE_MIXER_UI_DEVICE, GvcMixerUIDevicePrivate))
-
 struct GvcMixerUIDevicePrivate
 {
         gchar                      *first_line_desc;
@@ -64,7 +62,7 @@ static void     gvc_mixer_ui_device_finalize   (GObject               *object);
 static void     gvc_mixer_ui_device_set_icon_name (GvcMixerUIDevice *device,
                                                    const char       *icon_name);
 
-G_DEFINE_TYPE (GvcMixerUIDevice, gvc_mixer_ui_device, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (GvcMixerUIDevice, gvc_mixer_ui_device, G_TYPE_OBJECT)
 
 static guint32
 get_next_output_serial (void)
@@ -192,7 +190,7 @@ gvc_mixer_ui_device_constructor (GType                  type,
 static void
 gvc_mixer_ui_device_init (GvcMixerUIDevice *device)
 {
-        device->priv = GVC_MIXER_UI_DEVICE_GET_PRIVATE (device);
+        device->priv = gvc_mixer_ui_device_get_instance_private (device);
 }
 
 static void
@@ -290,8 +288,6 @@ gvc_mixer_ui_device_class_init (GvcMixerUIDeviceClass *klass)
                                      NULL,
                                      G_PARAM_READWRITE|G_PARAM_CONSTRUCT);
         g_object_class_install_property (object_class, PROP_ICON_NAME, pspec);
-
-        g_type_class_add_private (klass, sizeof (GvcMixerUIDevicePrivate));
 }
 
 /* Removes the part of the string that starts with skip_prefix


### PR DESCRIPTION
Based on https://github.com/GNOME/libgnome-volume-control/commit/13a4a9a5c2badae9d18b9b437573be5c65b772d7