### PR TITLE
Always parse date/time integers in base-10

### DIFF
--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -2999,7 +2999,7 @@ stack_is (SlideShow *parser,
 static int
 parse_int (const char *text)
 {
-	return strtol (text, NULL, 0);
+	return strtol (text, NULL, 10);
 }
 
 static void


### PR DESCRIPTION
Ref: https://github.com/GNOME/gnome-desktop/commit/db0e20607050c7c859446420905cc8680249554a#diff-2449085de556a57f2376e17c247ae29bf6b3f4c60a15b979b494a82c12e6171d

"People might prefix their dates/times with 0 which leads to the number
being interpreted as octal value. This can then lead to "08" being
interpreted as 0, because 8 is not a valid octal value. This is also
much more likely than people intentionally trying to use octal or hex
values for dates/times."