### PR TITLE
Stop using deprecated GTimeVal/g_get_current_time

### DIFF
--- a/libcinnamon-desktop/gnome-bg-crossfade.c
+++ b/libcinnamon-desktop/gnome-bg-crossfade.c
@@ -309,11 +309,13 @@ get_current_time (void)
 {
 	const double microseconds_per_second = (double) G_USEC_PER_SEC;
 	double timestamp;
-	GTimeVal now;
+	GDateTime *now;
 
-	g_get_current_time (&now);
+	now = (GDateTime *) g_get_real_time ();
 
-	timestamp = ((microseconds_per_second * now.tv_sec) + now.tv_usec) /
+	timestamp = ((microseconds_per_second *
+                    g_date_time_get_second (now)) +
+                    g_date_time_get_microsecond (now)) /
 	            microseconds_per_second;
 
 	return timestamp;

--- a/libcinnamon-desktop/gnome-bg.c
+++ b/libcinnamon-desktop/gnome-bg.c
@@ -1897,11 +1897,13 @@ struct _SlideShow
 static double
 now (void)
 {
-	GTimeVal tv;
+	GDateTime *time;
 
-	g_get_current_time (&tv);
+	time = (GDateTime *) g_get_real_time ();
 
-	return (double)tv.tv_sec + (tv.tv_usec / 1000000.0);
+	return (double) g_date_time_get_second (time) +
+                       (g_date_time_get_microsecond (time) /
+		        1000000.0);
 }
 
 static Slide *


### PR DESCRIPTION
It is Y2038 unsafe, GDateTime and g_get_real_time should be used.

Ref: https://developer.gnome.org/glib/stable/glib-GDateTime.html


------------------------------------

Did it myself for once :D