### PR TITLE
Add screen reader keybinding for improve accessibility

### DIFF
--- a/schemas/org.cinnamon.desktop.keybindings.media-keys.gschema.xml.in.in
+++ b/schemas/org.cinnamon.desktop.keybindings.media-keys.gschema.xml.in.in
@@ -142,7 +142,7 @@
       <_description>Binding to launch the web browser.</_description>
     </key>
     <key name="screenreader" type="as">
-      <default>['']</default>
+      <default>['&lt;Alt&gt;&lt;Super&gt;s']</default>
       <_summary>Toggle screen reader</_summary>
       <_description>Binding to start the screen reader</_description>
     </key>


### PR DESCRIPTION
The screen reader keybinding was not set as default and was one of the
things making difficult have good accessibility support in cinnamon.
This commit will add keybinding Alt+Super+s like the gnome one,
improving slightly the accessibility.