### PR TITLE
Fix build warnings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Clement Lefebvre <root@linuxmint.com>
 Build-Depends:
  debhelper-compat (= 12),
- dh-python,
  dpkg-dev (>= 1.15.1),
  gobject-introspection (>= 0.10.2-1~),
  gtk-doc-tools (>= 1.4),
@@ -29,7 +28,7 @@ Standards-Version: 3.9.6
 Package: cinnamon-desktop-data
 Architecture: all
 Multi-Arch: foreign
-Depends: python3, python3-gi, ${misc:Depends}, ${python3:Depends}
+Depends: ${misc:Depends}
 Description: Common files for Cinnamon desktop apps
  This package includes files that are shared between several Cinnamon
  apps (i18n files and configuration schemas).
@@ -37,21 +36,21 @@ Description: Common files for Cinnamon desktop apps
 Package: gir1.2-cinnamondesktop-3.0
 Section: introspection
 Architecture: any
-Depends: ${gir:Depends}, ${misc:Depends}, ${shlibs:Depends}
+Depends: ${gir:Depends}, ${misc:Depends}
 Description: Introspection data for CinnamonDesktop
  This package contains the introspection data for libcinnamon-desktop.
 
 Package: gir1.2-cvc-1.0
 Section: introspection
 Architecture: any
-Depends: ${gir:Depends}, ${misc:Depends}, ${shlibs:Depends}
+Depends: ${gir:Depends}, ${misc:Depends}
 Description: Introspection data for Cinnamon pulseaudio abstraction
  This package contains the introspection data for Cinnamon pulseaudio
  abstraction.
 
 Package: libcinnamon-desktop-dbg
 Section: debug
-Priority: extra
+Priority: optional
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
@@ -88,7 +87,7 @@ Description: Cinnamon shared utility library.
 
 Package: libcvc-dbg
 Section: debug
-Priority: extra
+Priority: optional
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Build-Depends:
  libxkbfile-dev,
  libxml2-dev (>= 2.4.20),
  libxrandr-dev (>= 2:1.3),
- meson,
+ meson (>= 0.50.0),
  python3:any,
  xkb-data,
  yelp-tools,

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 export DEB_BUILD_MAINT_OPTIONS = hardening=+bindnow
 
 %:
-	dh $@ --with=gir,python3
+	dh $@ --with=gir
 
 override_dh_auto_configure:
 	dh_auto_configure -- \

--- a/libcinnamon-desktop/gnome-bg-crossfade.c
+++ b/libcinnamon-desktop/gnome-bg-crossfade.c
@@ -65,10 +65,7 @@ enum {
 
 static guint signals[NUMBER_OF_SIGNALS] = { 0 };
 
-G_DEFINE_TYPE (GnomeBGCrossfade, gnome_bg_crossfade, G_TYPE_OBJECT)
-#define GNOME_BG_CROSSFADE_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o),\
-			                   GNOME_TYPE_BG_CROSSFADE,\
-			                   GnomeBGCrossfadePrivate))
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeBGCrossfade, gnome_bg_crossfade, G_TYPE_OBJECT)
 
 static void
 gnome_bg_crossfade_set_property (GObject      *object,
@@ -195,14 +192,12 @@ gnome_bg_crossfade_class_init (GnomeBGCrossfadeClass *fade_class)
 					  G_SIGNAL_RUN_LAST, 0, NULL, NULL,
 					  g_cclosure_marshal_VOID__OBJECT,
 					  G_TYPE_NONE, 1, G_TYPE_OBJECT);
-
-	g_type_class_add_private (gobject_class, sizeof (GnomeBGCrossfadePrivate));
 }
 
 static void
 gnome_bg_crossfade_init (GnomeBGCrossfade *fade)
 {
-	fade->priv = GNOME_BG_CROSSFADE_GET_PRIVATE (fade);
+	fade->priv = gnome_bg_crossfade_get_instance_private (fade);
 
 	fade->priv->fading_surface = NULL;
 	fade->priv->end_surface = NULL;

--- a/libcinnamon-desktop/gnome-desktop-thumbnail.c
+++ b/libcinnamon-desktop/gnome-desktop-thumbnail.c
@@ -73,13 +73,8 @@ static const char *appname = "gnome-thumbnail-factory";
 static void gnome_desktop_thumbnail_factory_init          (GnomeDesktopThumbnailFactory      *factory);
 static void gnome_desktop_thumbnail_factory_class_init    (GnomeDesktopThumbnailFactoryClass *class);
 
-G_DEFINE_TYPE (GnomeDesktopThumbnailFactory,
-	       gnome_desktop_thumbnail_factory,
-	       G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeDesktopThumbnailFactory, gnome_desktop_thumbnail_factory, G_TYPE_OBJECT)
 #define parent_class gnome_desktop_thumbnail_factory_parent_class
-
-#define GNOME_DESKTOP_THUMBNAIL_FACTORY_GET_PRIVATE(object) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((object), GNOME_DESKTOP_TYPE_THUMBNAIL_FACTORY, GnomeDesktopThumbnailFactoryPrivate))
 
 typedef struct {
     gint width;
@@ -826,7 +821,7 @@ gnome_desktop_thumbnail_factory_init (GnomeDesktopThumbnailFactory *factory)
 {
   GnomeDesktopThumbnailFactoryPrivate *priv;
   
-  factory->priv = GNOME_DESKTOP_THUMBNAIL_FACTORY_GET_PRIVATE (factory);
+  factory->priv = gnome_desktop_thumbnail_factory_get_instance_private (factory);
 
   priv = factory->priv;
   priv->size = GNOME_DESKTOP_THUMBNAIL_SIZE_NORMAL;
@@ -865,8 +860,6 @@ gnome_desktop_thumbnail_factory_class_init (GnomeDesktopThumbnailFactoryClass *c
   gobject_class = G_OBJECT_CLASS (class);
 	
   gobject_class->finalize = gnome_desktop_thumbnail_factory_finalize;
-
-  g_type_class_add_private (class, sizeof (GnomeDesktopThumbnailFactoryPrivate));
 }
 
 /**

--- a/libcinnamon-desktop/gnome-pnp-ids.c
+++ b/libcinnamon-desktop/gnome-pnp-ids.c
@@ -25,8 +25,6 @@
 
 static void     gnome_pnp_ids_finalize     (GObject     *object);
 
-#define GNOME_PNP_IDS_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNOME_TYPE_PNP_IDSS, GnomePnpIdsPrivate))
-
 struct _GnomePnpIdsPrivate
 {
         gchar                           *table_data;
@@ -35,7 +33,7 @@ struct _GnomePnpIdsPrivate
 
 static gpointer gnome_pnp_ids_object = NULL;
 
-G_DEFINE_TYPE (GnomePnpIds, gnome_pnp_ids, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GnomePnpIds, gnome_pnp_ids, G_TYPE_OBJECT)
 
 typedef struct Vendor Vendor;
 struct Vendor
@@ -285,13 +283,12 @@ gnome_pnp_ids_class_init (GnomePnpIdsClass *klass)
 {
         GObjectClass *object_class = G_OBJECT_CLASS (klass);
         object_class->finalize = gnome_pnp_ids_finalize;
-        g_type_class_add_private (klass, sizeof (GnomePnpIdsPrivate));
 }
 
 static void
 gnome_pnp_ids_init (GnomePnpIds *pnp_ids)
 {
-        pnp_ids->priv = GNOME_PNP_IDS_GET_PRIVATE (pnp_ids);
+        pnp_ids->priv = gnome_pnp_ids_get_instance_private (pnp_ids);
 
         /* we don't keep malloc'd data in the hash; instead we read it
          * out into priv->table_data and then link to it in the hash */

--- a/libcinnamon-desktop/gnome-rr-config.c
+++ b/libcinnamon-desktop/gnome-rr-config.c
@@ -101,7 +101,7 @@ enum {
   PROP_LAST
 };
 
-G_DEFINE_TYPE (GnomeRRConfig, gnome_rr_config, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeRRConfig, gnome_rr_config, G_TYPE_OBJECT)
 
 typedef struct Parser Parser;
 
@@ -503,7 +503,7 @@ out:
 static void
 gnome_rr_config_init (GnomeRRConfig *self)
 {
-    self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GNOME_TYPE_RR_CONFIG, GnomeRRConfigPrivate);
+    self->priv = gnome_rr_config_get_instance_private (self);
 
     self->priv->clone = FALSE;
     self->priv->base_scale = BASE_SCALE_NOT_CONFIGURED;
@@ -831,8 +831,6 @@ static void
 gnome_rr_config_class_init (GnomeRRConfigClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (GnomeRROutputInfoPrivate));
 
     gobject_class->set_property = gnome_rr_config_set_property;
     gobject_class->finalize = gnome_rr_config_finalize;

--- a/libcinnamon-desktop/gnome-rr-labeler.c
+++ b/libcinnamon-desktop/gnome-rr-labeler.c
@@ -57,7 +57,7 @@ enum {
 	PROP_LAST
 };
 
-G_DEFINE_TYPE (GnomeRRLabeler, gnome_rr_labeler, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeRRLabeler, gnome_rr_labeler, G_TYPE_OBJECT);
 
 static void gnome_rr_labeler_finalize (GObject *object);
 static void setup_from_config (GnomeRRLabeler *labeler);
@@ -88,7 +88,7 @@ gnome_rr_labeler_init (GnomeRRLabeler *labeler)
 {
 	GdkWindow *gdkwindow;
 
-	labeler->priv = G_TYPE_INSTANCE_GET_PRIVATE (labeler, GNOME_TYPE_RR_LABELER, GnomeRRLabelerPrivate);
+	labeler->priv = gnome_rr_labeler_get_instance_private (labeler);
 
 	labeler->priv->workarea_atom = XInternAtom (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
 						    "_NET_WORKAREA",
@@ -129,8 +129,6 @@ static void
 gnome_rr_labeler_class_init (GnomeRRLabelerClass *klass)
 {
 	GObjectClass *object_class;
-
-	g_type_class_add_private (klass, sizeof (GnomeRRLabelerPrivate));
 
 	object_class = (GObjectClass *) klass;
 

--- a/libcinnamon-desktop/gnome-rr-output-info.c
+++ b/libcinnamon-desktop/gnome-rr-output-info.c
@@ -30,12 +30,12 @@
 #include "edid.h"
 #include "gnome-rr-private.h"
 
-G_DEFINE_TYPE (GnomeRROutputInfo, gnome_rr_output_info, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeRROutputInfo, gnome_rr_output_info, G_TYPE_OBJECT)
 
 static void
 gnome_rr_output_info_init (GnomeRROutputInfo *self)
 {
-    self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GNOME_TYPE_RR_OUTPUT_INFO, GnomeRROutputInfoPrivate);
+    self->priv = gnome_rr_output_info_get_instance_private (self);
 
     self->priv->name = NULL;
     self->priv->on = FALSE;
@@ -58,8 +58,6 @@ static void
 gnome_rr_output_info_class_init (GnomeRROutputInfoClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (GnomeRROutputInfoPrivate));
 
     gobject_class->finalize = gnome_rr_output_info_finalize;
 }

--- a/libcinnamon-desktop/gnome-rr.c
+++ b/libcinnamon-desktop/gnome-rr.c
@@ -161,6 +161,7 @@ static void gnome_rr_screen_get_property (GObject*, guint, GValue*, GParamSpec*)
 static gboolean gnome_rr_screen_initable_init (GInitable*, GCancellable*, GError**);
 static void gnome_rr_screen_initable_iface_init (GInitableIface *iface);
 G_DEFINE_TYPE_WITH_CODE (GnomeRRScreen, gnome_rr_screen, G_TYPE_OBJECT,
+        G_ADD_PRIVATE (GnomeRRScreen)
         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, gnome_rr_screen_initable_iface_init))
 
 G_DEFINE_BOXED_TYPE (GnomeRRCrtc, gnome_rr_crtc, crtc_copy, crtc_free)
@@ -849,7 +850,6 @@ void
 gnome_rr_screen_class_init (GnomeRRScreenClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
-    g_type_class_add_private (klass, sizeof (GnomeRRScreenPrivate));
 
     gobject_class->set_property = gnome_rr_screen_set_property;
     gobject_class->get_property = gnome_rr_screen_get_property;
@@ -939,7 +939,7 @@ gnome_rr_screen_class_init (GnomeRRScreenClass *klass)
 void
 gnome_rr_screen_init (GnomeRRScreen *self)
 {
-    GnomeRRScreenPrivate *priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GNOME_TYPE_RR_SCREEN, GnomeRRScreenPrivate);
+    GnomeRRScreenPrivate *priv = gnome_rr_screen_get_instance_private (self);
     self->priv = priv;
 
     priv->gdk_screen = NULL;

--- a/libcinnamon-desktop/gnome-wall-clock.c
+++ b/libcinnamon-desktop/gnome-wall-clock.c
@@ -58,7 +58,7 @@ enum {
 	PROP_FORMAT_STRING,
 };
 
-G_DEFINE_TYPE (GnomeWallClock, gnome_wall_clock, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeWallClock, gnome_wall_clock, G_TYPE_OBJECT);
 
 /* Date/Time format defaults - options are stored in org.cinnamon.desktop.interface keys.
  * The wall clock is used variously in Cinnamon applets and desklets, as well as
@@ -112,7 +112,7 @@ gnome_wall_clock_init (GnomeWallClock *self)
 {
 	GFile *tz;
 
-	self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GNOME_TYPE_WALL_CLOCK, GnomeWallClockPrivate);
+	self->priv = gnome_wall_clock_get_instance_private (self);
 	
 	self->priv->clock_string = NULL;
 	
@@ -244,8 +244,6 @@ gnome_wall_clock_class_init (GnomeWallClockClass *klass)
                                      "The string to format the clock to",
                                      NULL,
                                      G_PARAM_READABLE | G_PARAM_WRITABLE));
-
-	g_type_class_add_private (gobject_class, sizeof (GnomeWallClockPrivate));
 }
 
 static void

--- a/libcinnamon-desktop/gnome-xkb-info.c
+++ b/libcinnamon-desktop/gnome-xkb-info.c
@@ -89,7 +89,7 @@ struct _GnomeXkbInfoPrivate
   gchar **current_parser_text;
 };
 
-G_DEFINE_TYPE (GnomeXkbInfo, gnome_xkb_info, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (GnomeXkbInfo, gnome_xkb_info, G_TYPE_OBJECT);
 
 static void
 free_layout (gpointer data)
@@ -637,7 +637,7 @@ ensure_rules_are_parsed (GnomeXkbInfo *self)
 static void
 gnome_xkb_info_init (GnomeXkbInfo *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, GNOME_TYPE_XKB_INFO, GnomeXkbInfoPrivate);
+  self->priv = gnome_xkb_info_get_instance_private (self);
 }
 
 static void
@@ -663,8 +663,6 @@ gnome_xkb_info_class_init (GnomeXkbInfoClass *klass)
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
   gobject_class->finalize = gnome_xkb_info_finalize;
-
-  g_type_class_add_private (gobject_class, sizeof (GnomeXkbInfoPrivate));
 }
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 
 # https://github.com/linuxmint/cinnamon-desktop
 project('cinnamon-desktop', 'c', version: '5.2.0',
-  meson_version: '>=0.41.0'
+  meson_version: '>=0.50.0'
 )
 
 # Before making a release, the LT_VERSION string should be modified.


### PR DESCRIPTION
* Fix build warnings due to deprecated macro G_TYPE_INSTANCE_GET_PRIVATE
* meson: fix minimum version (-> 0.50.0)
* packaging: fix lintian warnings
  * priority extra replaced by optional
  * removed python dependency for cinnamon-desktop-data (unneeded since #127) and dh-python
    * python3 is kept as build dep for `meson_install_schemas.py`
  * removed unneeded shlibs substvar for gir packages