### PR TITLE
Needs testing - gnome-rr.c: Migrate from g_memdup() go g_memdup2()

### DIFF
--- a/libcinnamon-desktop/gnome-rr.c
+++ b/libcinnamon-desktop/gnome-rr.c
@@ -1450,7 +1450,7 @@ get_property (Display *dpy,
     
     if (actual_type == XA_INTEGER && actual_format == 8)
     {
-	result = g_memdup (prop, nitems);
+	result = g_memdup2 (prop, nitems);
 	if (len)
 	    *len = nitems;
     }
@@ -1699,7 +1699,7 @@ output_copy (const GnomeRROutput *from)
     output->modes = (GnomeRRMode**) g_ptr_array_free (array, FALSE);
 
     output->edid_size = from->edid_size;
-    output->edid_data = g_memdup (from->edid_data, from->edid_size);
+    output->edid_data = g_memdup2 (from->edid_data, from->edid_size);
 
     return output;
 }
@@ -1749,7 +1749,7 @@ gnome_rr_output_get_ids_from_edid (GnomeRROutput         *output,
     if (!info)
         return FALSE;
     if (vendor)
-        *vendor = g_memdup (info->manufacturer_code, 4);
+        *vendor = g_memdup2 (info->manufacturer_code, 4);
     if (product)
         *product = info->product_code;
     if (serial)


### PR DESCRIPTION
Virtually no difference between the functions except for
byte_size becoming a gsize.

This is a measure to mitigate integer overflows.

See:
https://docs.gtk.org/glib/func.memdup2.html
https://discourse.gnome.org/t/port-your-module-from-g-memdup-to-g-memdup2-now/5538

------------

I still need to test this, don't accept yet