### PR TITLE
Fix testsound positions in cinnamon-settings

### DIFF
--- a/libcvc/gvc-channel-map.c
+++ b/libcvc/gvc-channel-map.c
@@ -228,7 +228,7 @@ gvc_channel_map_get_mapping (const GvcChannelMap  *map)
 /**
  * gvc_channel_map_has_position:
  * @map:
- * @position:
+ * @position: (type int)
  *
  * Returns:
  */


### PR DESCRIPTION
This fixes a problem in cinnamon-settings where the available speaker positions for testsounds did not correspond to the actual setup.