### PR TITLE
Fix outdated defaults in schemas

### DIFF
--- a/schemas/org.cinnamon.desktop.background.gschema.xml.in
+++ b/schemas/org.cinnamon.desktop.background.gschema.xml.in
@@ -11,7 +11,7 @@
       </description>
     </key>
     <key name="picture-uri" type="s">
-      <default>'file://@datadir@/themes/Adwaita/backgrounds/adwaita-timed.xml'</default>
+      <default>'file://@datadir@/backgrounds/gnome/adwaita-l.jxl'</default>
       <summary>Picture URI</summary>
       <description>
         URI to use for the background image. Not that the backend only supports

--- a/schemas/org.cinnamon.desktop.interface.gschema.xml.in
+++ b/schemas/org.cinnamon.desktop.interface.gschema.xml.in
@@ -102,7 +102,7 @@
       </description>
     </key>
     <key name="icon-theme" type="s">
-      <default>'gnome'</default>
+      <default>'AdwaitaLegacy'</default>
       <summary>Icon Theme</summary>
       <description>
         Icon theme to use for the panel, nautilus etc.


### PR DESCRIPTION
adwaita-timed.xml was removed upstream: https://github.com/GNOME/gnome-backgrounds/commit/3f4dcb89b4ca0e9853e0babbdd93da9c87046072

As for the icon theme, because Adwaita is blacklisted, this uses AdwaitaLegacy instead, which is a drop-in replacement for the "gnome" icon theme.