### PR TITLE
Add keys to screensaver gsettings schema

### DIFF
--- a/schemas/org.cinnamon.desktop.screensaver.gschema.xml.in
+++ b/schemas/org.cinnamon.desktop.screensaver.gschema.xml.in
@@ -145,5 +145,13 @@
       <summary>Specify custom screen locker command</summary>
       <description>If empty, cinnamon-screensaver will be used</description>
     </key>
+    <key name="hide-unlock-button" type="b">
+      <default>false</default>
+      <summary>Hide unlock button.</summary>
+    </key>
+    <key name="hide-on-screen-keyboard-button" type="b">
+      <default>false</default>
+      <summary>Hide on screen keyboard button</summary>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
  hide-unlock-button
  hide-on-screen-keyboard-button

I like clean look and these 2 buttons is unnecessary for me, so I would like to add the ability to hide them
related: https://github.com/linuxmint/cinnamon-screensaver/pull/467