### PR TITLE
Cvc null check profile

### DIFF
--- a/libcvc/gvc-mixer-control.c
+++ b/libcvc/gvc-mixer-control.c
@@ -547,11 +547,10 @@ gvc_mixer_control_change_profile_on_selected_device (GvcMixerControl  *control,
         g_return_val_if_fail (GVC_IS_MIXER_UI_DEVICE (device), FALSE);
 
         g_object_get (G_OBJECT (device), "card", &card, NULL);
-        current_profile = gvc_mixer_card_get_profile(card);
+        current_profile = gvc_mixer_card_get_profile (card);
 
         if (!current_profile) {
-          g_warning("gvc_mixer_card_get_profile() returned NULL for card %p",
-                    card);
+          g_warning("gvc_mixer_card_get_profile() returned NULL for card %p", card);
           return FALSE;
         }
         

--- a/libcvc/gvc-mixer-control.c
+++ b/libcvc/gvc-mixer-control.c
@@ -547,8 +547,14 @@ gvc_mixer_control_change_profile_on_selected_device (GvcMixerControl  *control,
         g_return_val_if_fail (GVC_IS_MIXER_UI_DEVICE (device), FALSE);
 
         g_object_get (G_OBJECT (device), "card", &card, NULL);
-        current_profile = gvc_mixer_card_get_profile (card);
+        current_profile = gvc_mixer_card_get_profile(card);
 
+        if (!current_profile) {
+          g_warning("gvc_mixer_card_get_profile() returned NULL for card %p",
+                    card);
+          return FALSE;
+        }
+        
         if (current_profile)
                 best_profile = gvc_mixer_ui_device_get_best_profile (device, profile, current_profile->profile);
         else

--- a/libcvc/gvc-mixer-ui-device.c
+++ b/libcvc/gvc-mixer-ui-device.c
@@ -556,7 +556,12 @@ gvc_mixer_ui_device_get_active_profile (GvcMixerUIDevice* device)
                 return NULL;
         }
 
-        profile = gvc_mixer_card_get_profile (device->priv->card);
+        profile = gvc_mixer_card_get_profile(device->priv->card);
+        if (!profile) {
+                g_warning("gvc_mixer_card_get_profile() returned NULL for card %p", device->priv->card);
+                return NULL;
+        }
+        
         return gvc_mixer_ui_device_get_matching_profile (device, profile->profile);
 }
 

--- a/libcvc/gvc-mixer-ui-device.c
+++ b/libcvc/gvc-mixer-ui-device.c
@@ -556,9 +556,9 @@ gvc_mixer_ui_device_get_active_profile (GvcMixerUIDevice* device)
                 return NULL;
         }
 
-        profile = gvc_mixer_card_get_profile(device->priv->card);
+        profile = gvc_mixer_card_get_profile (device->priv->card);
         if (!profile) {
-                g_warning("gvc_mixer_card_get_profile() returned NULL for card %p", device->priv->card);
+                g_warning ("gvc_mixer_card_get_profile() returned NULL for card %p", device->priv->card);
                 return NULL;
         }
         


### PR DESCRIPTION
This PR addresses #253 by adding NULL checks for `gvc_mixer_card_get_profile()` in two locations:

- `gvc_mixer_ui_device_get_matching_profile()` (in `gvc-mixer-ui-device.c`)
- `gvc_mixer_control_change_output()` (in `gvc-mixer-control.c`)

Previously, if `gvc_mixer_card_get_profile()` returned NULL (e.g., during initial Bluetooth connection), it could cause Cinnamon to crash into fallback mode. These checks prevent that by logging a warning and safely returning a value that can be handled (`NULL` & `FALSE`)

Tested locally with Sony WH-1000XM4 headphones on Linux Mint 21.3.
