### PR TITLE
gnome-xkb-info.c: Scan additional rules locations.

### DIFF
--- a/libcinnamon-desktop/meson.build
+++ b/libcinnamon-desktop/meson.build
@@ -122,6 +122,16 @@ gnome.generate_gir(libcinnamon_desktop,
   install: true,
 )
 
+executable('test-xkb-info',
+  'test-xkb-info.c',
+  include_directories: [ rootInclude ],
+  c_args: [
+    '-DGNOME_DESKTOP_USE_UNSTABLE_API',
+  ],
+  dependencies: [ glib, gtk ],
+  link_with: libcinnamon_desktop,
+)
+
 # FIXME
 # https://github.com/mesonbuild/meson/issues/1687
 custom_target('gsettings-enums',

--- a/libcinnamon-desktop/test-xkb-info.c
+++ b/libcinnamon-desktop/test-xkb-info.c
@@ -1,4 +1,3 @@
-#define GNOME_DESKTOP_USE_UNSTABLE_API
 #include <libcinnamon-desktop/gnome-xkb-info.h>
 int
 main (int argc, char **argv)


### PR DESCRIPTION
Loads ~/.config/xkb, ~/.xkb, /etc/xkb (in that order) prior to the main ones from the xkbcommon package.

They're valid locations in the xkb spec, but we were only loading those in /usr/share/X11/xkb/rules.

Fixes https://github.com/linuxmint/cinnamon/issues/13528.